### PR TITLE
Budget lines are now editable

### DIFF
--- a/client/src/components/addBudgetCategory.jsx
+++ b/client/src/components/addBudgetCategory.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 
-class BudgetCategoryForm extends Component {
+class AddBudgetCategory extends Component {
 
-  constructor (props){
+  constructor(props) {
     super(props)
     this.state={
       category: '',
@@ -27,10 +27,10 @@ class BudgetCategoryForm extends Component {
     this.setState({[stateName]: stateValue})
   }
 
-  theBudgetCategoryForm(){
+  theBudgetCategoryForm() {
     return (
       <div>
-        <form className="add-budget-category">
+        <form className="budget-category">
           <label htmlFor="category">Category</label>
           <input
             id="category" 
@@ -60,9 +60,9 @@ class BudgetCategoryForm extends Component {
     if (this.props.renderForm === 'show') {
       return (
         <div>
-          {this.theBudgetCategoryForm()}
-          <button className="add-budget-category" onClick= { this.handleSubmit }>Submit </button>
-          <button onClick= { renderToggle }>Clear</button>
+          { this.theBudgetCategoryForm() }
+          <button className="add-budget-category" onClick = { this.handleSubmit }>Submit </button>
+          <button onClick = { renderToggle }>Clear</button>
         </div>
       )
     }
@@ -73,18 +73,15 @@ class BudgetCategoryForm extends Component {
     }
   }
 
-  render() {
-    console.log(`The budget category props are --> `, this.props)
-    return (<div>{this.renderCreateBudgetCategoryForm()}</div>)
-  }
+  render() { return this.renderCreateBudgetCategoryForm() }
 }
                 
 // PropTypes tell other developers what `props` a component expects
 // Warnings will be shown in the console when the defined rules are violated
-BudgetCategoryForm.propTypes = {
+AddBudgetCategory.propTypes = {
   // budget: PropTypes.array
 };
 
 // In the ES6 spec, files are "modules" and do not share a top-level scope.
 // `var` declarations will only exist globally where explicitly defined.
-export default BudgetCategoryForm;
+export default AddBudgetCategory;

--- a/client/src/components/app.jsx
+++ b/client/src/components/app.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import axios from 'axios';
 
 import Budget from './budget.jsx';
-import BudgetCategoryForm from './budgetCategoryForm.jsx';
+import AddBudgetCategory from './addBudgetCategory.jsx';
 import BudgetHoursAnalysis from './budgetHoursAnalysis.jsx';
-import { sumBudgetHours } from '../utils/sumBudgetHours.js';
+import sumBudgetHours from '../utils/sumBudgetHours.js';
 
 class App extends React.Component {
   constructor(props) {
@@ -22,7 +22,7 @@ class App extends React.Component {
     this.deleteLineItem = this.deleteLineItem.bind(this);
     this.budgetItemForm = this.budgetItemForm.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.toggleCreateBudgetCategoryForm = this.toggleCreateBudgetCategoryForm.bind(this);
+    this.toggleViewMode = this.toggleViewMode.bind(this);
     this.fetchBudgetData = this.fetchBudgetData.bind(this);
     
     this.sumBudgetHours = sumBudgetHours.bind(this);
@@ -42,7 +42,7 @@ class App extends React.Component {
     }
     if (event.target.className === "edit-budget-line") {
       console.log(`Let's edit a budget line`)
-      this.budgetItemForm(arguments[1])
+      
     }
     if (event.target.className === "delete-budget-line") {
       console.log(`Let's delete a budget line`)
@@ -57,7 +57,7 @@ class App extends React.Component {
     console.log(`The budget line to edit is`, budgetLine)
   }
 
-  toggleCreateBudgetCategoryForm() {
+  toggleViewMode() {
     if (this.state.renderForm === 'show') { 
       this.setState({renderForm: 'hide'})
     } else {
@@ -74,9 +74,9 @@ class App extends React.Component {
       .catch( (error) => { console.log(`There was an error with the Axios POST --> `, error) })
   }
 
-  editLineItem (budgetItemId, budgetLIneData) {
+  editLineItem ({ budgetItemId, budgetLineData }) {
     const instance = axios.create({ baseURL: 'http://localhost:8080' })
-    instance.put(`/updateBudgetItem/${budgetItemId}`, budgetLIneData) // budgetLineData needs to be defined
+    instance.put(`/updateBudgetItem/${budgetItemId}`, budgetLineData) // budgetLineData needs to be defined
       .then( (response) => {
         console.log('The response data from the server PUT is --> \n', response.data)
         this.fetchBudgetData(this.state.budgetId)
@@ -115,25 +115,32 @@ class App extends React.Component {
     return (
       <div>
         <h1>Welcome to your time budget!</h1>
-        <div id="username">
+        <div id = "username">
           <h2 >User: { this.state.user }</h2>
         </div>
-        <div id="budget-name">
+        <div id = "budget-name">
           <h2>Budget: { this.state.budgetName }</h2>
         </div>
-        <div id="category-form">
-          <BudgetCategoryForm onClick={this.handleClick} renderForm={this.state.renderForm} renderToggle={this.toggleCreateBudgetCategoryForm}/>
+        <div id = "category-form">
+          <AddBudgetCategory 
+            onClick={this.handleClick} 
+            renderForm={this.state.renderForm}
+            renderToggle={this.toggleViewMode}
+          />
         </div>
-        <div id="budget">
+        <div id = "budget">
           <Budget
             budget = { this.state.budget }
             commitBudgetCategory = { this.handleClick }
-            editLineItem = { this.handleClick }
+            editLineItem = { this.editLineItem }
             deleteLineItem = { this.handleClick }
           />
         </div>
         <div>
-          <button className="visualize-budget" onClick={ this.handleClick }>Visualize</button>
+          <button 
+            className = "visualize-budget"
+            onClick = { this.handleClick }> Visualize
+          </button>
         </div>
         <div>
           <BudgetHoursAnalysis budgetHours={ this.state.budgetHours }/>

--- a/client/src/components/budget.jsx
+++ b/client/src/components/budget.jsx
@@ -1,25 +1,27 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import BudgetLine from './budgetLine.jsx'
 
-const Budget = (props) => {
-  return (
-    <div>
+class Budget extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {}
+  }
+
+  render(){
+    return (
       <div className="budget">
-        { props.budget.map( (budgetItem, index) => <BudgetLine 
+        { this.props.budget.map( (budgetItem, index) => <BudgetLine 
           budgetLine = { budgetItem } 
           key = {`budgetItem`+index}
           id = { index }
-          editLineItem = { props.editLineItem }
-          deleteLineItem = { props.deleteLineItem } 
+          editLineItem = { this.props.editLineItem }
+          deleteLineItem = { this.props.deleteLineItem } 
         /> )}
       </div>
-      <div> 
-        <button className="add-budget-category" onClick={ props.commitBudgetCategory }> Add Random Budget Category</button>
-      </div>
-    </div>
-  )
+    )
+  }
 }
 
 // PropTypes tell other developers what `props` a component expects

--- a/client/src/components/budgetline.jsx
+++ b/client/src/components/budgetline.jsx
@@ -1,17 +1,79 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import BudgetCategoryForm from './budgetCategoryForm.jsx'
+class BudgetLine extends Component {
 
-const BudgetLine = (props) => {
-  return (
-    <div id={props.budgetLine.budget_item_id}>
-      <ul>{props.budgetLine.category} for {props.budgetLine.hours_allocated}
-      <button className="edit-budget-line" onClick={ (e) => props.editLineItem(e, props) }>Modify</button>
-      <button className="delete-budget-line" onClick={ (e) => props.deleteLineItem(e, props) }>Remove</button>
-      </ul>
-    </div>
-  )
+  constructor(props) {
+    super(props)
+    this.state={
+      viewMode: 'read-only',
+      budgetItemId: props.budgetLine.budget_item_id,
+      category: props.budgetLine.category,
+      hoursAllocated: props.budgetLine.hours_allocated,
+      tempCategoryForm: props.budgetLine.category,
+      tempHoursAllocatedForm: props.budgetLine.hours_allocated,
+    }
+    this.handleCancel = this.handleCancel.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleModify = this.handleModify.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.renderEditableBudgetForm = this.renderEditableBudgetForm.bind(this);
+  }
+
+  handleCancel() {
+    const category = this.state.category;
+    const hoursAllocated = this.state.hoursAllocated;
+    this.setState({tempCategoryForm: category, tempHoursAllocatedForm: hoursAllocated, viewMode: 'read-only'})
+  }
+
+  handleChange(event) {
+    const stateName = event.target.id;
+    const stateValue = event.target.value;
+    this.setState({[stateName]: stateValue})
+  }
+
+  handleModify() {
+    this.setState({ viewMode: 'edit' })
+  }
+
+  handleSubmit() {
+    const category = this.state.tempCategoryForm;
+    const hoursAllocated = this.state.tempHoursAllocatedForm;
+    this.setState({ category, hoursAllocated, viewMode: 'read-only' }, () => {
+      this.props.editLineItem({budgetItemId: this.state.budgetItemId, budgetLineData: {category, hoursAllocated}})
+    })
+  }
+
+  renderEditableBudgetForm() {
+    const { viewMode, budgetItemId, category, hoursAllocated, tempCategoryForm, tempHoursAllocatedForm } = this.state;
+    if (viewMode === 'read-only') {
+      return (
+        <div id={budgetItemId}>
+          <ul>{ category } for { hoursAllocated }
+          <button className="edit-budget-line" onClick={ this.handleModify }>Modify</button>
+          <button className="delete-budget-line" onClick={ (e) => this.props.deleteLineItem(e, this.props) }>Remove</button>
+          </ul>
+        </div>
+      )
+    } else if (viewMode === 'edit') {
+      return (
+        <div>
+          <form className="budget-category">
+            <label htmlFor="category">Category</label>
+            <input id="tempCategoryForm" name="category" value={ tempCategoryForm } onChange={ this.handleChange } placeholder={ category }></input>
+            <label htmlFor="hoursAllocated">Hours</label>
+            <input id="tempHoursAllocatedForm" name="hours" value={ tempHoursAllocatedForm } onChange={ this.handleChange } placeholder={ hoursAllocated }></input>
+          </form>
+          <button className="edit-budget-line" onClick={ this.handleSubmit }>Submit</button>
+          <button className="cancel-edit" onClick={ this.handleCancel }>Cancel</button>
+        </div>
+      )
+    }
+  }
+
+  render() {
+    { return this.renderEditableBudgetForm() }
+  }
 }
 
 // PropTypes tell other developers what `props` a component expects


### PR DESCRIPTION
On clicking of the modify budget, we handle the modify which changes our `viewMode` to editable and displays a form.
When the form is submitted, we update state and send a put message to the database via the passed props.

This diff addresses #15 and makes the app a full CRUD app.